### PR TITLE
docs: fix typos in documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ This interval, with default value 10 seconds, can only be changed globally,
 and only before any sampling seed or JMX bean has started recording.
 For example, this call changes the NMT recording interval from the default to 5 seconds:
 ```java
-PeridodicAggregator.setIntervalSeconds(5);
+PeriodicAggregator.setIntervalSeconds(5);
 ```
 
 #### NMT Sampling
@@ -232,7 +232,7 @@ These alternative JAR files are created:
 - With all dependencies included ("fat JAR"): `pollianna-<version>-all.jar`.
 - With all dependencies included and isolated ("iso JAR"): `pollianna-<version>-iso.jar`.
   Must be used as command line agent.
-  All dependencies will be isolated from the application by a custom class loader with a separate claspath.
+  All dependencies will be isolated from the application by a custom class loader with a separate classpath.
 
 ## Testing
 ```shell

--- a/docs/gc-specifics.md
+++ b/docs/gc-specifics.md
@@ -39,7 +39,7 @@ So far, this variability below the initial size has only been observed with G1.
 The "Serial" collector is selected by the JVM command line option ```-XX:+UseSerialGC```.
 
 It is a "stop-the-world" collector:
-application execution is always suspened for the entire time when the GC is active.
+application execution is always suspended for the entire time when the GC is active.
 Therefore, GC pauses and GC cycles are interchangeable, with identical count and duration metric values.
 It is sufficient to monitor either of these and omit the other.
 
@@ -56,7 +56,7 @@ The Parallel collector is the default in JDK 8.
 It is explicitly selected by the JVM command line option ```-XX:+UseParallellGC```.
 
 It is a "stop-the-world" collector:
-application execution is always suspened for the entire time when the GC is active.
+application execution is always suspended for the entire time when the GC is active.
 Therefore, GC pauses and GC cycles are interchangeable, with identical count and duration metric values.
 It is sufficient to monitor either of these and omit the other.
 
@@ -70,7 +70,7 @@ because they do not establish a complete live set of objects.
 The Concurrent Mark-Sweep collector is selected by the JVM command line option ```-XX:+UseConcMarkSweepGC```.
 
 It is a partially concurrent collector: 
-application execution is only suspened for some of the times when the GC is active.
+application execution is only suspended for some of the times when the GC is active.
 GC pauses and GC cycles usually differ,
 except for young generation collections,
 which are still executed in a stop-the-world manner.
@@ -87,7 +87,7 @@ The G1 collector is the default as of JDK 9.
 It is explicitly selected by the JVM command line option ```-XX:+UseG1GC```.
 
 It is a partially concurrent collector:
-application execution is only suspened for some of the times when the GC is active.
+application execution is only suspended for some of the times when the GC is active.
 GC pauses and GC cycles usually differ,
 except for pure young generation collections,
 which are still executed in a stop-the-world manner.

--- a/docs/metrics-list.md
+++ b/docs/metrics-list.md
@@ -1,4 +1,4 @@
-# Polliana Metrics Choices
+# Pollianna Metrics Choices
 
 These types of metric sets are available:
 - Aggregated essential metrics for [best practices standard JVM monitoring](#JVM-Essentials), or a select subset thereof.
@@ -122,7 +122,7 @@ As GC cycles can overlap with polling intervals, their calculated runtime portio
 An allocation rate sample is formed by the difference between 
 how full the Java heap is at the beginning of a GC
 and how full it was at the end of the preceding GC, 
-divided by the time between those two meaasurements.
+divided by the time between those two measurements.
 
 | JMX Attribute                |  Type  |    Unit    | Description                                    |
 |:-----------------------------|:------:|:----------:|:-----------------------------------------------|
@@ -144,7 +144,7 @@ Occupancy is only updated as new samples become available. Otherwise, the previo
 |:------------------------|:------:|:----:|:------------------------------------------|
 | GcAggregateOccupancyMin | double |  %   | Lowest detected heap occupancy percentage |
 | GcAggregateOccupancyAvg | double |  %   | Average heap occupancy percentage         |
-| GcAggregateOccupancyMax | double |  %   | Higest detected heap occupancy percentage |
+| GcAggregateOccupancyMax | double |  %   | Highest detected heap occupancy percentage |
 
 ### Java Heap Workload
 
@@ -169,7 +169,7 @@ So far, this variability below the initial size has only been observed with G1.
 |:-----------------------|:------:|:----:|:-----------------------------------------|
 | GcAggregateWorkloadMin | double |  %   | Lowest detected heap workload percentage |
 | GcAggregateWorkloadAvg | double |  %   | Average heap workload percentage         |
-| GcAggregateWorkloadMax | double |  %   | Higest detected heap workload percentage |
+| GcAggregateWorkloadMax | double |  %   | Highest detected heap workload percentage |
 
 ### Direct Buffer Memory
 
@@ -277,7 +277,7 @@ but it provides aggregates in the following form.
 
 | JMX Attribute              | Type |  Unit  | Description                                         |
 |:---------------------------|:----:|:------:|:----------------------------------------------------|
-| RtAggregateMappedMemoryMin | long | bytes  | Minimun memory used by file-mapped buffers          |
+| RtAggregateMappedMemoryMin | long | bytes  | Minimum memory used by file-mapped buffers          |
 | RtAggregateMappedMemoryAvg | long | bytes  | Average memory used by file-mapped buffers          |
 | RtAggregateMappedMemoryMax | long | bytes  | Maximum memory used by file-mapped buffers          |
 | RtStartedThreadCount       | long | number | Number of platform threads created and then started |


### PR DESCRIPTION
## Summary

This PR fixes various typos across the documentation files and README.

## Changes

| File | Line | Typo | Fix |
|------|------|------|-----|
| docs/metrics-list.md | 1 | Polliana | Pollianna |
| docs/metrics-list.md | 125 | meaasurements | measurements |
| docs/metrics-list.md | 147 | Higest | Highest |
| docs/metrics-list.md | 172 | Higest | Highest |
| docs/metrics-list.md | 280 | Minimun | Minimum |
| docs/gc-specifics.md | 42 | suspened | suspended |
| docs/gc-specifics.md | 59 | suspened | suspended |
| docs/gc-specifics.md | 73 | suspened | suspended |
| docs/gc-specifics.md | 90 | suspened | suspended |
| README.md | 194 | PeridodicAggregator | PeriodicAggregator |
| README.md | 235 | claspath | classpath |

## Testing

No functional changes - documentation only.